### PR TITLE
SGA-60: Fix "Humigadget Settings cannot be entered"

### DIFF
--- a/app/src/main/java/com/sensirion/smartgadget/view/device_management/ScanDeviceFragment.java
+++ b/app/src/main/java/com/sensirion/smartgadget/view/device_management/ScanDeviceFragment.java
@@ -252,8 +252,10 @@ public class ScanDeviceFragment extends ParentListFragment implements ScanListen
         Executors.newSingleThreadExecutor().execute(new Runnable() {
             @Override
             public void run() {
-                while (true) {
+                byte numberTries = 0;
+                while (++numberTries < DEVICE_SYNCHRONIZATION_MAX_NUMBER_SYNCHRONIZATION_TRIES) {
                     try {
+                        RHTHumigadgetSensorManager.getInstance().synchronizeDeviceServices(device);
                         Thread.sleep(DEVICE_SYNCHRONIZATION_TIMEOUT_MILLISECONDS);
                         break;
                     } catch (@NonNull final InterruptedException e) {


### PR DESCRIPTION
- If the user wants to open the settings of a connected but not
synchronized Humigadget (The application does not have all the
necessary information for entering the ManageDeviceFragment), the
application will force all the obtention of all the necessary data.